### PR TITLE
fix log compacting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hmdb"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "BSD-3-Clause"
 description = "Typesafe, read optimized, transactional, persistent, in-memory, key-value store"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ macro_rules! schema {
                 let mut data = vec![];
                 $(
                     for (key, val) in $table_name.get_all() {
-                        data.push(helper_log::$table_name::insert(key, val));
+                        data.push(helper_log::$table_name::insert(key.clone(), val.clone()));
                     }
                 )*
 

--- a/tests/schema_tests.rs
+++ b/tests/schema_tests.rs
@@ -135,7 +135,7 @@ pub mod schema {
         db1.word_counts.insert("test".to_string(), 5).unwrap();
 
         db1.transaction(|db| {
-            let mut num = db.word_counts.get(&"test".to_string()).unwrap();
+            let mut num = *db.word_counts.get(&"test".to_string()).unwrap();
             num += 1;
             db.word_counts.insert("test".to_string(), num).unwrap();
         })
@@ -172,7 +172,7 @@ pub mod schema {
             thread_db
                 .transaction(|db| {
                     std::thread::sleep(Duration::from_secs(1));
-                    let mut num = db.word_counts.get(&"test".to_string()).unwrap();
+                    let mut num = *db.word_counts.get(&"test".to_string()).unwrap();
                     num += 1;
                     db.word_counts.insert("test".to_string(), num).unwrap();
                 })


### PR DESCRIPTION
Log compacting broke in version 0.2.0 because `transaction.rs` was rolled back. This should fix log compacting while still keeping the changes in `transaction.rs`.